### PR TITLE
made payment type nullible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
-# README title
+# Bangazon API
 
 ### High-Level Description
-
+Bangazon API provides endpoints for developers to access the bangazon.com database.
 ### Installation Instructions
+1. Fork and/or clone this repo.
+1. Ensure you have Rails ~> 5.1.4 installed.
+1. Run `bundle install` to install the necessary gems.
+1. Run `rails server`.
 
 ### Dependency List with Version Numbers
+* Rails ~> 5.1.4
+* sqlite3
+* puma ~> 3.7
+* rack-cors ~> 1.0
+* faker ~> 1.7
+* byebug
+* listen >= 3.0.5
+* spring
+* spring-watcher-listen ~> 2.0.0
+* tzinfo-data
 
 ### Team Members
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,6 +3,6 @@ class Customer < ApplicationRecord
   has_many :orders
 
 
-  validates_presence_of :customer_first_name, :customer_last_name, :customer_acct_date,:customer_active
+  validates_presence_of :customer_first_name, :customer_last_name, :customer_acct_date
 
 end

--- a/db/migrate/20171020164829_create_orders.rb
+++ b/db/migrate/20171020164829_create_orders.rb
@@ -2,7 +2,7 @@ class CreateOrders < ActiveRecord::Migration[5.1]
   def change
     create_table :orders do |t|
       t.references :customers, index: true, null: false, foreign_key: true
-      t.references :pay_methods, index: true, null: false, foreign_key: true
+      t.references :pay_methods, index: true, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20171020165222) do
 
   create_table "orders", force: :cascade do |t|
     t.integer "customers_id", null: false
-    t.integer "pay_methods_id", null: false
+    t.integer "pay_methods_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customers_id"], name: "index_orders_on_customers_id"


### PR DESCRIPTION
### Pull Requests

#### Descriptions

Per product owner, made 'payment type' field on 'order' table nullible.

A re-migration will be necessary.

#### Steps to Test

in Postman:

localhost:3000/orders
{
	"orders": {
		"customers_id": 1,
		"pay_methods_id": null
	}
}

#### Link to Feature Ticket

n/a